### PR TITLE
Cashe old layer

### DIFF
--- a/seedpod_ground_risk/main.py
+++ b/seedpod_ground_risk/main.py
@@ -76,6 +76,7 @@ class LayerItemDelegate(QWidget):
         self._plot_worker.remove_layer(self._layer)
 
     def edit_layer(self):
+        old_layer = self._layer
         self._plot_worker.remove_layer(self._layer)
         wizard = LayerWizard(self, Qt.Window)
         wizard.exec_()  # Open wizard and block until result
@@ -83,6 +84,8 @@ class LayerItemDelegate(QWidget):
             layerObj = list(LAYER_OBJECTS.values())[wizard.layerType]
             layer = layerObj(wizard.layerKey, **wizard.opts)
             self._plot_worker.add_layer(layer)
+        else:
+            self._plot_worker.add_layer(old_layer)
 
     def export_path_json(self):
         from PySide2.QtWidgets import QFileDialog


### PR DESCRIPTION
The edit layer function on the layer list now caches the old layer and reimplements it if the layer wizard is cancelled instead of accepted.