### PR TITLE
Fix graph regen

### DIFF
--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -145,6 +145,7 @@ class PlotServer:
         hvPlot = self.compose_overlay_plot(self._x_range, self._y_range)
         if self._preload_complete:
             self._progress_bar_callback(100)
+            self._progress_callback("Plotting complete")
         fig = hv.render(hvPlot, backend='bokeh')
         fig.output_backend = 'webgl'
 

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -239,6 +239,8 @@ class PlotServer:
             # Just display map tiles in case this was transient
             import traceback
             traceback.print_exc()
+            self._progress_callback(
+                f'Plotting failed with the following error: {e}. Please attempt to re-generate the plot')
             print(e)
             plot = self._base_tiles
 

--- a/seedpod_ground_risk/layers/osm_tag_layer.py
+++ b/seedpod_ground_risk/layers/osm_tag_layer.py
@@ -204,7 +204,7 @@ def query_osm_polygons(osm_tag, bound_poly: sg.Polygon) -> gpd.GeoDataFrame:
 
 
 def query_request(overpass_url, osm_tag, bounds):
-    headers = {'User-Agent': 'seedpod-ground-risk v0.13.0 (Python 3.8/requests v2.25.1;)',
+    headers = {'User-Agent': f'seedpod-ground-risk v0.13.0 (Python 3.8/requests v{requests.__version__};)',
                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
     query = """
               [out:json]

--- a/seedpod_ground_risk/layers/osm_tag_layer.py
+++ b/seedpod_ground_risk/layers/osm_tag_layer.py
@@ -8,6 +8,7 @@ import shapely.geometry as sg
 from holoviews.element import Geometry
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
+# TODO The below line is a symptom of us not varifying the SSL certs.
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 from seedpod_ground_risk.layers.blockable_data_layer import BlockableDataLayer

--- a/seedpod_ground_risk/layers/osm_tag_layer.py
+++ b/seedpod_ground_risk/layers/osm_tag_layer.py
@@ -204,6 +204,8 @@ def query_osm_polygons(osm_tag, bound_poly: sg.Polygon) -> gpd.GeoDataFrame:
 
 
 def query_request(overpass_url, osm_tag, bounds):
+    headers = {'User-Agent': 'seedpod-ground-risk v0.13.0 (Python 3.8/requests v2.25.1;)',
+               'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
     query = """
               [out:json]
               [timeout:30]
@@ -218,7 +220,7 @@ def query_request(overpass_url, osm_tag, bounds):
               out center qt;
           """.format(tag=osm_tag,
                      s_bound=bounds[0], w_bound=bounds[1], n_bound=bounds[2], e_bound=bounds[3])
-    resp = requests.post(overpass_url, data={'data': query}, verify=False)
+    resp = requests.post(overpass_url, data={'data': query}, headers=headers, verify=False)
     data = resp.json()
     return resp, data
 

--- a/seedpod_ground_risk/layers/osm_tag_layer.py
+++ b/seedpod_ground_risk/layers/osm_tag_layer.py
@@ -18,6 +18,8 @@ def query_osm_polygons(osm_tag, bound_poly: sg.Polygon) -> gpd.GeoDataFrame:
     """
     from time import time
     import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
     t0 = time()
     bounds = bound_poly.bounds
@@ -46,7 +48,7 @@ def query_osm_polygons(osm_tag, bound_poly: sg.Polygon) -> gpd.GeoDataFrame:
         overpass_url2 = "https://overpass.kumi.systems/api/interpreter"
         resp = requests.get(overpass_url2, params={'data': query}, verify=False)
     if resp.status_code != 200:
-        print(resp)
+        print(f'OSM Tag Layer failed with{resp}')
 
     data = resp.json()
     print("OSM query took ", time() - t0)

--- a/seedpod_ground_risk/layers/osm_tag_layer.py
+++ b/seedpod_ground_risk/layers/osm_tag_layer.py
@@ -36,9 +36,18 @@ def query_osm_polygons(osm_tag, bound_poly: sg.Polygon) -> gpd.GeoDataFrame:
               out center qt;
           """.format(tag=osm_tag,
                      s_bound=bounds[0], w_bound=bounds[1], n_bound=bounds[2], e_bound=bounds[3])
-    resp = requests.get(overpass_url, params={'data': query})
+    resp = requests.get(overpass_url, params={'data': query}, verify=False)
     if resp.status_code != 200:
         print(resp)
+        overpass_url1 = "https://lz4.overpass-api.de/api/interpreter"
+        resp = requests.get(overpass_url1, params={'data': query}, verify=False)
+    elif resp.status_code != 200:
+        print(resp)
+        overpass_url2 = "https://overpass.kumi.systems/api/interpreter"
+        resp = requests.get(overpass_url2, params={'data': query}, verify=False)
+    if resp.status_code != 200:
+        print(resp)
+
     data = resp.json()
     print("OSM query took ", time() - t0)
 

--- a/seedpod_ground_risk/layers/osm_tag_layer.py
+++ b/seedpod_ground_risk/layers/osm_tag_layer.py
@@ -25,7 +25,9 @@ def query_osm_polygons(osm_tag, bound_poly: sg.Polygon) -> gpd.GeoDataFrame:
     t0 = time()
     bounds = bound_poly.bounds
     overpass_urls = ["https://overpass.kumi.systems/api/interpreter", "https://lz4.overpass-api.de/api/interpreter",
-                     "https://z.overpass-api.de/api/interpreter"]
+                     "https://z.overpass-api.de/api/interpreter", "https://overpass.openstreetmap.ru/api/interpreter",
+                     "https://overpass.openstreetmap.fr/api/interpreter",
+                     "https://overpass.nchc.org.tw/api/interpreter"]
     for i, url in enumerate(overpass_urls):
         resp, data = query_request(overpass_urls[i], osm_tag, bounds)
         if resp.status_code == 200:

--- a/seedpod_ground_risk/layers/osm_tag_layer.py
+++ b/seedpod_ground_risk/layers/osm_tag_layer.py
@@ -218,7 +218,7 @@ def query_request(overpass_url, osm_tag, bounds):
               out center qt;
           """.format(tag=osm_tag,
                      s_bound=bounds[0], w_bound=bounds[1], n_bound=bounds[2], e_bound=bounds[3])
-    resp = requests.get(overpass_url, params={'data': query}, verify=False)
+    resp = requests.post(overpass_url, data={'data': query}, verify=False)
     data = resp.json()
     return resp, data
 

--- a/seedpod_ground_risk/layers/osm_tag_layer.py
+++ b/seedpod_ground_risk/layers/osm_tag_layer.py
@@ -25,7 +25,7 @@ def query_osm_polygons(osm_tag, bound_poly: sg.Polygon) -> gpd.GeoDataFrame:
     t0 = time()
     bounds = bound_poly.bounds
     overpass_urls = ["https://overpass.kumi.systems/api/interpreter", "https://lz4.overpass-api.de/api/interpreter",
-                     "https://overpass.kumi.systems/api/interpreter"]
+                     "https://z.overpass-api.de/api/interpreter"]
     for i, url in enumerate(overpass_urls):
         resp, data = query_request(overpass_urls[i], osm_tag, bounds)
         if resp.status_code == 200:

--- a/seedpod_ground_risk/layers/strike_risk_layer.py
+++ b/seedpod_ground_risk/layers/strike_risk_layer.py
@@ -80,7 +80,7 @@ def wrap_row_pipeline(row, shape, padded_pdf, padded_centre, sm):
 
 class StrikeRiskLayer(BlockableDataLayer):
     def __init__(self, key, colour: str = None, blocking=False, buffer_dist=0,
-                 ac: dict = AIRCRAFT_LIST['SPOTTER'],
+                 ac: dict = AIRCRAFT_LIST['Default'],
                  wind_vel: float = 1, wind_dir: float = 220):
         super().__init__(key, colour, blocking, buffer_dist)
         delattr(self, '_colour')

--- a/static_data/aircraft_list.json
+++ b/static_data/aircraft_list.json
@@ -10,7 +10,7 @@
     "glide_ratio": 14,
     "cruise_speed": 25,
     "cruise_alt": 100,
-    "failure_prob": 0.05
+    "failure_prob": 0.01
   },
   "SPOTTER": {
     "width": 4,


### PR DESCRIPTION
This PR adds more URLs for the program to try upon one of them not responding correctly. It also now displays a message to the user giving them the error that has occurred and asking them to regenerate the plot. 

It should be noted that something has happened recently which means that the SSL certificate was throwing errors when trying to access the Overpass API. Until I figure out how we can fix this the varify flag has been set to False. As no secure data is being transmitted this should be ok for now, however, if we have to start using API keys then this needs to be fixed. 