### PR TITLE
Risk Map Match Feature 

### DIFF
--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -59,19 +59,11 @@ class PlotServer:
         self.data_layers = [
             # TemporalPopulationEstimateLayer('Temporal Pop. Est'),
             # RoadsLayer('Road Traffic Population/Hour')
-            FatalityRiskLayer('Fatality Risk', ac='GA MQ-9 Reaper'),
+            FatalityRiskLayer('Fatality Risk'),
             # ResidentialLayer('Residential Layer')
         ]
 
-        from seedpod_ground_risk.layers.pathfinding_layer import PathfindingLayer
-        from seedpod_ground_risk.pathfinding.theta_star import RiskThetaStar
-        from seedpod_ground_risk.ui_resources.aircraft_options import AIRCRAFT_LIST
-        from seedpod_ground_risk.pathfinding.heuristic import ManhattanRiskHeuristic
-        self.annotation_layers = [
-            PathfindingLayer('BLACKFIELD', (50.818949, -1.373442), (50.933505, -1.432153),
-
-                             RiskThetaStar, AIRCRAFT_LIST['Default'], ManhattanRiskHeuristic,
-                             1e-8)]
+        self.annotation_layers = []
 
         self.plot_size = plot_size
         self._progress_callback = progress_callback if progress_callback is not None else lambda *args: None

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -212,6 +212,7 @@ class PlotServer:
                     if self.annotation_layers:
                         plot = Overlay([self._generated_data_layers[plt_lyr][0]])
                         res = []
+                        prog_bar = 50
                         for dlayer in self.data_layers:
                             raster_indices = dict(Longitude=np.linspace(x_range[0], x_range[1], num=raster_shape[0]),
                                                   Latitude=np.linspace(y_range[0], y_range[1], num=raster_shape[1]))
@@ -224,9 +225,13 @@ class PlotServer:
 
                             for alayer in self.annotation_layers:
                                 if alayer.aircraft == dlayer.ac_dict:
+                                    self._progress_bar_callback(prog_bar)
+                                    prog_bar += 40 / len(self.annotation_layers)
+                                    self._progress_callback(f'Finding a path for {alayer.aircraft["name"]}')
                                     res.append(alayer.annotate(raw_data, (raster_indices, raster_grid)))
 
-                        self._progress_callback('Annotating Layers...')
+                        self._progress_callback('Plotting paths')
+                        self._progress_bar_callback(90)
                         # res = jl.Parallel(n_jobs=1, verbose=1, backend='threading')(
                         #     jl.delayed(layer.annotate)(raw_datas, (raster_indices, raster_grid)) for layer in
                         #     self.annotation_layers )

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -63,7 +63,6 @@ class PlotServer:
             # ResidentialLayer('Residential Layer')
         ]
 
-        self.annotation_layers = []
 
         self.plot_size = plot_size
         self._progress_callback = progress_callback if progress_callback is not None else lambda *args: None
@@ -198,6 +197,13 @@ class PlotServer:
 
                     t0 = time()
                     self._progress_bar_callback(10)
+                    if len(self.annotation_layers) > 0:
+                        for alayer in self.annotation_layers:
+                            for dlayer in self.data_layers:
+                                if alayer.aircraft != dlayer.ac_dict:
+                                    self.remove_layer(dlayer)
+                                    new_layer = FatalityRiskLayer('Fatality Risk', ac=alayer.aircraft['name'])
+                                    self.add_layer(new_layer)
                     self.generate_layers(bounds_poly, raster_shape)
                     self._progress_bar_callback(50)
                     plot = Overlay([res[0] for res in self._generated_data_layers.values()])

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -198,13 +198,20 @@ class PlotServer:
 
                     t0 = time()
                     self._progress_bar_callback(10)
+                    new_data_layers = []
+                    old_data_layers = []
                     if len(self.annotation_layers) > 0:
                         for alayer in self.annotation_layers:
                             for dlayer in self.data_layers:
                                 if alayer.aircraft != dlayer.ac_dict:
-                                    self.remove_layer(dlayer)
+                                    old_data_layers.append((dlayer))
                                     new_layer = FatalityRiskLayer('Fatality Risk', ac=alayer.aircraft['name'])
-                                    self.add_layer(new_layer)
+                                    new_data_layers.append(new_layer)
+                    for old_lay in old_data_layers:
+                        self.remove_layer(old_lay)
+                    for new_lay in new_data_layers:
+                        self.add_layer(new_lay)
+                    self._progress_bar_callback(20)
                     self.generate_layers(bounds_poly, raster_shape)
                     self._progress_bar_callback(50)
                     plot = Overlay([res[0] for res in self._generated_data_layers.values()])

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -59,10 +59,11 @@ class PlotServer:
         self.data_layers = [
             # TemporalPopulationEstimateLayer('Temporal Pop. Est'),
             # RoadsLayer('Road Traffic Population/Hour')
-            FatalityRiskLayer('Fatality Risk'),
+            FatalityRiskLayer('Fatality Risk SPOTTER 000@0kts'),
             # ResidentialLayer('Residential Layer')
         ]
 
+        self.annotation_layers = []
 
         self.plot_size = plot_size
         self._progress_callback = progress_callback if progress_callback is not None else lambda *args: None

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -366,6 +366,15 @@ class PlotServer:
                 popup.exec()
                 break
 
+    def remove_duplicate_layers(self):
+        # TODO Make the list/set method work as the nested for loop is clunky
+        # self.data_layers = list(set(self.data_layers))
+
+        for i, layer1 in enumerate(self.data_layers):
+            for j, layer2 in enumerate(self.data_layers):
+                if layer1.ac_dict == layer2.ac_dict and i != j:
+                    self.remove_layer(layer2)
+
     def _get_raster_dimensions(self, bounds_poly: sg.Polygon, raster_resolution_m: float) -> Tuple[int, int]:
         """
         Return a the (x,y) shape of a raster grid given its EPSG4326 envelope and desired raster resolution

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -232,12 +232,6 @@ class PlotServer:
                         # res = jl.Parallel(n_jobs=1, verbose=1, backend='threading')(
                         #     jl.delayed(layer.annotate)(raw_datas, (raster_indices, raster_grid)) for layer in
                         #     self.annotation_layers )
-
-                        # In serial is functionally equal to above
-                        # res = []
-                        # for layer in self.annotation_layers:
-                        #     res.append(layer.annotate(raw_datas, (raster_indices, raster_grid)))
-
                         plot = Overlay(
                             [self._base_tiles, plot, *[annot for annot in res if annot is not None]]).collate()
                     else:

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -368,7 +368,7 @@ class PlotServer:
         from seedpod_ground_risk.layers.fatality_risk_layer import FatalityRiskLayer
         for dlayer in self.data_layers:
             if isinstance(dlayer, FatalityRiskLayer) and layer.aircraft == dlayer.ac_dict:
-                cur_layer = GridEnvironment(self._generated_data_layers['Fatality Risk'][1])
+                cur_layer = GridEnvironment(self._generated_data_layers[dlayer.key][1])
                 grid = cur_layer.grid
                 popup = DataWindow(layer, grid)
                 popup.exec()

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -215,14 +215,12 @@ class PlotServer:
                         for dlayer in self.data_layers:
                             raster_indices = dict(Longitude=np.linspace(x_range[0], x_range[1], num=raster_shape[0]),
                                                   Latitude=np.linspace(y_range[0], y_range[1], num=raster_shape[1]))
-                            for keys in self._generated_data_layers:
-                                if dlayer.key == keys:
-                                    raw_data = [self._generated_data_layers[keys][2]]
-                                    raster_grid = np.sum(
-                                        [remove_raster_nans(self._generated_data_layers[keys][1])],
-                                        axis=0)
-                                    raster_grid = np.flipud(raster_grid)
-                                    raster_indices['Latitude'] = np.flip(raster_indices['Latitude'])
+                            raw_data = [self._generated_data_layers[dlayer.key][2]]
+                            raster_grid = np.sum(
+                                [remove_raster_nans(self._generated_data_layers[dlayer.key][1])],
+                                axis=0)
+                            raster_grid = np.flipud(raster_grid)
+                            raster_indices['Latitude'] = np.flip(raster_indices['Latitude'])
 
                             for alayer in self.annotation_layers:
                                 if alayer.aircraft == dlayer.ac_dict:

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -295,6 +295,8 @@ class PlotServer:
         Tuple[str, Tuple[Geometry, np.ndarray, gpd.GeoDataFrame]], Tuple[str, None]]:
 
         try:
+            if isinstance(layer, FatalityRiskLayer):
+                layer.key = f'{layer.key} {layer.ac} {layer.wind_dir:03d}@{layer.wind_vel}kts'
             result = layer.key, layer.generate(bounds_poly, raster_shape, from_cache=False, hour=hour,
                                                resolution=resolution)
             return result

--- a/seedpod_ground_risk/core/plot_server.py
+++ b/seedpod_ground_risk/core/plot_server.py
@@ -198,6 +198,7 @@ class PlotServer:
 
                     t0 = time()
                     self._progress_bar_callback(10)
+                    # TODO: This will give multiple data layers, these need to be able to fed into their relevent pathfinding layers
                     new_data_layers = []
                     old_data_layers = []
                     if len(self.annotation_layers) > 0:

--- a/seedpod_ground_risk/layers/fatality_risk_layer.py
+++ b/seedpod_ground_risk/layers/fatality_risk_layer.py
@@ -9,11 +9,16 @@ from seedpod_ground_risk.ui_resources.aircraft_options import AIRCRAFT_LIST
 
 class FatalityRiskLayer(BlockableDataLayer):
 
-    def __init__(self, key, ac: dict = AIRCRAFT_LIST['Default'],
+    def __init__(self, key, ac: str = 'Default',
                  wind_vel: float = 0, wind_dir: float = 0, colour: str = None, blocking=False, buffer_dist=0,
                  **kwargs):
         super().__init__(key, colour, blocking, buffer_dist)
-        self._strike_layer = StrikeRiskLayer(f'{key}_strike_', ac=ac, wind_vel=wind_vel, wind_dir=wind_dir,
+        self.ac = ac
+        self.wind_vel = wind_vel
+        self.wind_dir = wind_dir
+        self.ac_dict = AIRCRAFT_LIST[ac]
+        self._strike_layer = StrikeRiskLayer(f'{key}_strike_', ac=self.ac_dict, wind_vel=self.wind_vel,
+                                             wind_dir=self.wind_dir,
                                              buffer_dist=buffer_dist, **kwargs)
         delattr(self, '_colour')
 

--- a/seedpod_ground_risk/layers/fatality_risk_layer.py
+++ b/seedpod_ground_risk/layers/fatality_risk_layer.py
@@ -4,13 +4,17 @@ import numpy as np
 from seedpod_ground_risk.layers.blockable_data_layer import BlockableDataLayer
 from seedpod_ground_risk.layers.strike_risk_layer import StrikeRiskLayer
 from seedpod_ground_risk.path_analysis.harm_models.fatality_model import FatalityModel
+from seedpod_ground_risk.ui_resources.aircraft_options import AIRCRAFT_LIST
 
 
 class FatalityRiskLayer(BlockableDataLayer):
 
-    def __init__(self, key, colour: str = None, blocking=False, buffer_dist=0, **kwargs):
+    def __init__(self, key, ac: dict = AIRCRAFT_LIST['Default'],
+                 wind_vel: float = 0, wind_dir: float = 0, colour: str = None, blocking=False, buffer_dist=0,
+                 **kwargs):
         super().__init__(key, colour, blocking, buffer_dist)
-        self._strike_layer = StrikeRiskLayer(f'{key}_strike_', buffer_dist=buffer_dist, **kwargs)
+        self._strike_layer = StrikeRiskLayer(f'{key}_strike_', ac=ac, wind_vel=wind_vel, wind_dir=wind_dir,
+                                             buffer_dist=buffer_dist, **kwargs)
         delattr(self, '_colour')
 
     def preload_data(self):

--- a/seedpod_ground_risk/layers/strike_risk_layer.py
+++ b/seedpod_ground_risk/layers/strike_risk_layer.py
@@ -81,7 +81,7 @@ def wrap_row_pipeline(row, shape, padded_pdf, padded_centre, sm):
 class StrikeRiskLayer(BlockableDataLayer):
     def __init__(self, key, colour: str = None, blocking=False, buffer_dist=0,
                  ac: dict = AIRCRAFT_LIST['Default'],
-                 wind_vel: float = 1, wind_dir: float = 220):
+                 wind_vel: float = 0, wind_dir: float = 0):
         super().__init__(key, colour, blocking, buffer_dist)
         delattr(self, '_colour')
 

--- a/seedpod_ground_risk/main.py
+++ b/seedpod_ground_risk/main.py
@@ -252,7 +252,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         wizard = AircraftWizard(self, Qt.Window)
         wizard.exec()
         ac = wizard.d
+        stat_string = wizard.stat_str
         add_aircraft(ac)
+        self.status_update(stat_string)
 
     def time_changed(self, value):
         from seedpod_ground_risk.layers.roads_layer import generate_week_timesteps

--- a/seedpod_ground_risk/ui_resources/aircraft_options.py
+++ b/seedpod_ground_risk/ui_resources/aircraft_options.py
@@ -12,7 +12,6 @@ def aircraft_list():
 def add_aircraft(new_ac):
     ac_list = AIRCRAFT_LIST
     ac_list[f"{new_ac['name']}"] = new_ac
-    if 'name' in ac_list[f"{new_ac['name']}"]: del ac_list[f"{new_ac['name']}"]['name']
     with open(aircraft_list_filepath(), 'w') as f:
         json.dump(ac_list, f)
 

--- a/seedpod_ground_risk/ui_resources/layer_options.py
+++ b/seedpod_ground_risk/ui_resources/layer_options.py
@@ -82,7 +82,7 @@ AIRCRAFT_PARAMETERS = {
 
 dummy_aircraft_variable = {
     "Select Aircraft...": {
-        "name": "Aliaksi",
+        "name": "Aliaksei",
         "width": 0,
         "length": 0,
         "mass": 0,

--- a/seedpod_ground_risk/ui_resources/layer_options.py
+++ b/seedpod_ground_risk/ui_resources/layer_options.py
@@ -82,6 +82,7 @@ AIRCRAFT_PARAMETERS = {
 
 dummy_aircraft_variable = {
     "Select Aircraft...": {
+        "name": "Aliaksi",
         "width": 0,
         "length": 0,
         "mass": 0,

--- a/seedpod_ground_risk/ui_resources/new_aircraft_wizard.py
+++ b/seedpod_ground_risk/ui_resources/new_aircraft_wizard.py
@@ -36,7 +36,7 @@ class AircraftWizard(QWizard):
 
         self.addPage(NewAircraftInfoPage(self))
 
-        self.setWindowTitle('Add Layer')
+        self.setWindowTitle('Add Aircraft')
 
         # TODO: Going back in wizard does not clear page fields.
         # Hook into back button click and remove and re add page.

--- a/seedpod_ground_risk/ui_resources/new_aircraft_wizard.py
+++ b/seedpod_ground_risk/ui_resources/new_aircraft_wizard.py
@@ -5,6 +5,7 @@ from PySide2.QtCore import QRegExp
 from PySide2.QtGui import QRegExpValidator
 from PySide2.QtWidgets import QWizard, QWizardPage, QLabel, QLineEdit, QGridLayout
 
+from seedpod_ground_risk.ui_resources.aircraft_options import AIRCRAFT_LIST
 from seedpod_ground_risk.ui_resources.layer_options import *
 
 
@@ -43,9 +44,20 @@ class AircraftWizard(QWizard):
 
     def accept(self) -> None:
         super().accept()
-        self.aircraftKey = self.field('name')
-        self.opts = {}
-        self.d = {}
-        for name, opt in AIRCRAFT_PARAMETERS.items():
-            self.d[f'{opt[1]}'] = opt[2](self.field(name))
-        return self.d
+        if self.field('Aircraft Name') in list(AIRCRAFT_LIST.keys()):
+            self.aircraftKey = self.field('Aircraft Name') + "(1)"
+            self.opts = {}
+            self.d = {}
+            self.stat_str = f"Aircraft saved as {self.aircraftKey} due to name duplication"
+            for name, opt in AIRCRAFT_PARAMETERS.items():
+                self.d[f'{opt[1]}'] = opt[2](self.field(name))
+            self.d['name'] = self.d['name'] + "(1)"
+            return self.d
+        else:
+            self.aircraftKey = self.field('name')
+            self.opts = {}
+            self.d = {}
+            self.stat_str = f"Aircraft saved as {self.aircraftKey}"
+            for name, opt in AIRCRAFT_PARAMETERS.items():
+                self.d[f'{opt[1]}'] = opt[2](self.field(name))
+            return self.d

--- a/static_data/aircraft_list.json
+++ b/static_data/aircraft_list.json
@@ -1,5 +1,6 @@
 {
   "Default": {
+    "name": "Default",
     "width": 2,
     "length": 1.5,
     "mass": 10,
@@ -13,6 +14,7 @@
     "failure_prob": 0.01
   },
   "SPOTTER": {
+    "name": "SPOTTER",
     "width": 4,
     "length": 3.5,
     "mass": 35,
@@ -26,6 +28,7 @@
     "failure_prob": 0.05
   },
   "Decode Mk2": {
+    "name": "Decode Mk2",
     "width": 4.2,
     "length": 3.5,
     "mass": 23,
@@ -39,6 +42,7 @@
     "failure_prob": 0.05
   },
   "Sulsa v2": {
+    "name": "Sulsa v2",
     "width": 1.2,
     "length": 1,
     "mass": 3,
@@ -52,6 +56,7 @@
     "failure_prob": 0.05
   },
   "GA MQ-9 Reaper": {
+    "name": "GA MQ-9 Reaper",
     "width": 20,
     "length": 17,
     "mass": 5300,


### PR DESCRIPTION
This feature ensures that the pathfinding algorithm isn't being based on a data layer with non-matching aircraft. It deletes the old Fatality Risk Layer and creates a new one that has the correct aircraft parameters. Fixes #70 , however still needs some work as currently it just runs through them, meaning the last one will be the only data layer that is produced. As we could be simulating multiple paths with different aircraft at once, I will be looking at how to connect the matching data layers to the relevant pathfinding layer. The issue then becomes which data layer you would want to be visualized. 

Draft PR so you can review how I am currently going about this process.